### PR TITLE
Update ModEntry.cs w/ null checks

### DIFF
--- a/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
@@ -103,7 +103,7 @@ namespace HitboxResizer
             bool isDefault = true;
 
             // null check
-            if (Game1.instance.contentManager.level.Info.Tags is null)
+            if (Game1.instance.contentManager?.level?.Info.Tags is null)
             {
                 return !isDefault;
             }


### PR DESCRIPTION
It would throw a NullReferenceException when vanilla is being loaded (because level is null). Which isn't a big deal if you don't have the Debugger running. 

Encountered Exception when trying to call 'On Level Start' method for mod 'Phoenixx19.HitboxResizer': System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at HitboxResizer.ModEntry.HasAnyHitboxResizerTags(Int32& width, Int32& height)
   at HitboxResizer.ModEntry.OnLevelStart()
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at JumpKing.Mods.ModLoader.CallOnLevelStartMethods()