### PR TITLE
Improvements and Bug Fixes for JumpKingTAS

### DIFF
--- a/WorkshopPlus/JumpKingTAS/JKAddons/FrameState.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/FrameState.cs
@@ -86,6 +86,13 @@ namespace JumpKingTAS
 			var stats = tAchievements.Field("m_all_time_stats").GetValue<PlayerStats>();
 			stats._ticks = Time;
 			tAchievements.Field("m_all_time_stats").SetValue(stats);
+
+			// while stepbacking with giant boots on
+			// there has a chance to disable body component on air
+			// then player can't move anymore
+			if (!OnGround && !body.Enabled) {
+				body.Enabled = true;
+			}
         }
 	}
 }

--- a/WorkshopPlus/JumpKingTAS/JKAddons/InputController.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/InputController.cs
@@ -130,7 +130,9 @@ namespace JumpKingTAS {
 					jump = Current.HasActions(Actions.Jump),
 					confirm = Current.HasActions(Actions.Jump),
 					cancel = Current.HasActions(Actions.Cancel),
-					pause = Current.HasActions(Actions.Pause)
+					pause = Current.HasActions(Actions.Pause),
+					boots = Current.HasActions(Actions.Boots),
+					snake = Current.HasActions(Actions.Snake)
 				};
 			}
 		}
@@ -150,6 +152,8 @@ namespace JumpKingTAS {
 						confirm = !previous.HasActions(Actions.Jump) && Current.HasActions(Actions.Jump),
 						cancel = !previous.HasActions(Actions.Cancel) && Current.HasActions(Actions.Cancel),
 						pause = !previous.HasActions(Actions.Pause) && Current.HasActions(Actions.Pause),
+						boots = !previous.HasActions(Actions.Boots) && Current.HasActions(Actions.Boots),
+						snake = !previous.HasActions(Actions.Snake) && Current.HasActions(Actions.Snake),
 					};
 				}
 			}

--- a/WorkshopPlus/JumpKingTAS/JKAddons/InputController.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/InputController.cs
@@ -112,7 +112,9 @@ namespace JumpKingTAS {
 					Current = inputs[++inputIndex];
 					frameToNext += Current.Frames;
 				}
-
+				// CAUTION: CurrentFrame increases after update.
+				// It is zero-indexed before playback 
+				// but one-indexed afterward (on CurrentInputFrame).
 				CurrentFrame++;
 			}
 		}
@@ -133,20 +135,26 @@ namespace JumpKingTAS {
 			}
 		}
 		public PadState GetPressed() {
-			InputRecord previous = Previous;
-			if (previous == null) {
-				return GetPadState();
-			} else {
-				return new PadState() {
-					up = !previous.HasActions(Actions.Up) && Current.HasActions(Actions.Up),
-					down = !previous.HasActions(Actions.Down) && Current.HasActions(Actions.Down),
-					left = !previous.HasActions(Actions.Left) && Current.HasActions(Actions.Left),
-					right = !previous.HasActions(Actions.Right) && Current.HasActions(Actions.Right),
-					jump = !previous.HasActions(Actions.Jump) && Current.HasActions(Actions.Jump),
-					confirm = !previous.HasActions(Actions.Jump) && Current.HasActions(Actions.Jump),
-					cancel = !previous.HasActions(Actions.Cancel) && Current.HasActions(Actions.Cancel),
-					pause = !previous.HasActions(Actions.Pause) && Current.HasActions(Actions.Pause)
-				};
+			// InputController update keypress after PlaybackPlayer()
+			if (CurrentInputFrame == 1) {
+				InputRecord previous = Previous;
+				if (previous == null) {
+					return GetPadState();
+				} else {
+					return new PadState() {
+						up = !previous.HasActions(Actions.Up) && Current.HasActions(Actions.Up),
+						down = !previous.HasActions(Actions.Down) && Current.HasActions(Actions.Down),
+						left = !previous.HasActions(Actions.Left) && Current.HasActions(Actions.Left),
+						right = !previous.HasActions(Actions.Right) && Current.HasActions(Actions.Right),
+						jump = !previous.HasActions(Actions.Jump) && Current.HasActions(Actions.Jump),
+						confirm = !previous.HasActions(Actions.Jump) && Current.HasActions(Actions.Jump),
+						cancel = !previous.HasActions(Actions.Cancel) && Current.HasActions(Actions.Cancel),
+						pause = !previous.HasActions(Actions.Pause) && Current.HasActions(Actions.Pause),
+					};
+				}
+			}
+			else {
+				return new PadState();
 			}
 		}
 		private bool ReadFile() {

--- a/WorkshopPlus/JumpKingTAS/JKAddons/InputRecord.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/InputRecord.cs
@@ -6,14 +6,17 @@ namespace JumpKingTAS {
 	public enum Actions {
 		None,
 		Left = 1,
-		Right = 2,
-		Up = 4,
-		Down = 8,
-		Jump = 16,
-		Pause = 32,
-		Cancel = 64,
-		Reset = 128,
-		State = 256
+		Right = 1<<1,
+		Up = 1<<2,
+		Down = 1<<3,
+		Jump = 1<<4,
+		Pause = 1<<5,
+		Cancel = 1<<6,
+		Reset = 1<<7,
+		State = 1<<8,
+		Boots = 1<<9,
+		Snake = 1<<10,
+
 	}
 	public class InputRecord {
 		public int Line { get; set; }
@@ -70,6 +73,8 @@ namespace JumpKingTAS {
 					case 'P': Actions ^= Actions.Pause; break;
 					case 'C': Actions ^= Actions.Cancel; break;
 					case 'X': Actions ^= Actions.Reset; break;
+					case 'B': Actions ^= Actions.Boots; break;
+					case 'S': Actions ^= Actions.Snake; break;
 				}
 
 				index++;
@@ -122,6 +127,8 @@ namespace JumpKingTAS {
 			if (HasActions(Actions.Pause)) { sb.Append(",P"); }
 			if (HasActions(Actions.Cancel)) { sb.Append(",C"); }
 			if (HasActions(Actions.Reset)) { sb.Append(",X"); }
+			if (HasActions(Actions.Boots)) { sb.Append(",B"); }
+			if (HasActions(Actions.Snake)) { sb.Append(",S"); }
 			if (HasActions(Actions.State)) { sb.Append($"@{PosX},{PosY},{Direction}"); }
 			return sb.ToString();
 		}

--- a/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
@@ -1,4 +1,4 @@
-﻿using JumpKing.Controller;
+using JumpKing.Controller;
 using JumpKing.GameManager;
 using JumpKing.Player;
 using JumpKing;
@@ -151,7 +151,7 @@ namespace JumpKingTAS
                     {
                         saves.Add(new FrameState(GameLoop.m_player));
                     }
-                    else
+                    else if(controller.CurrentFrame-1>=0)
                     {
                         saves[controller.CurrentFrame - 1].SetValues(GameLoop.m_player);
                     }

--- a/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
@@ -233,7 +233,7 @@ namespace JumpKingTAS
         {
             bool dpadUp = padState.DPad.Up == ButtonState.Pressed || (IsKeyDown(Keys.OemCloseBrackets) && !IsKeyDown(Keys.RightControl));
             bool dpadDown = padState.DPad.Down == ButtonState.Pressed || (IsKeyDown(Keys.OemOpenBrackets) && !IsKeyDown(Keys.RightControl));
-            bool leftStick = padState.Buttons.LeftStick == ButtonState.Pressed;
+            bool leftStick = padState.Buttons.LeftStick == ButtonState.Pressed || (IsKeyDown(Keys.RightShift) && !IsKeyDown(Keys.RightControl));
 
             if (HasFlag(state, State.Enable))
             {
@@ -284,9 +284,14 @@ namespace JumpKingTAS
                         controller.ReloadPlayback();
                     }
                 }
-                else if (HasFlag(state, State.FrameStep) && padState.ThumbSticks.Right.X < -0.1)
+                else if (HasFlag(state, State.FrameStep) && padState.ThumbSticks.Right.X < -0.1 || (IsKeyDown(Keys.RightAlt) && IsKeyDown(Keys.RightControl)))
                 {
                     float rStick = padState.ThumbSticks.Right.X;
+                    if (rStick > -0.1f)
+                    {
+                        rStick = -0.9f;
+                    }
+
                     FrameStepCooldown += (int)((rStick + 0.1) * 80f);
                     if (FrameStepCooldown <= 0)
                     {

--- a/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
@@ -86,6 +86,8 @@ namespace JumpKingTAS
                 PlayerStatus = null;
             }
         }
+        // Main update method which is called by Game1.update()
+        // and excuted before JumpGame.Update()
         public static void UpdateInputs()
         {
             UpdatePlayerInfo();
@@ -119,19 +121,10 @@ namespace JumpKingTAS
                         if (controller.Current.HasActions(Actions.Reset))
                         {
                             var m_all_time_stats = AchievementManager.Field("m_all_time_stats").GetValue<PlayerStats>();
-                            m_all_time_stats.attempts = 1;
-                            m_all_time_stats.falls = 0;
-                            m_all_time_stats.jumps = 0;
-                            m_all_time_stats.session = 0;
-                            m_all_time_stats._ticks = 0;
-                            AchievementManager.Field("m_all_time_stats").SetValue(m_all_time_stats);
 
                             var m_snapshot = AchievementManager.Field("m_snapshot").GetValue<PlayerStats>();
-                            m_snapshot.attempts = 1;
-                            m_snapshot.falls = 0;
-                            m_snapshot.jumps = 0;
-                            m_snapshot.session = 0;
-                            m_snapshot._ticks = 2;
+                            // Same as GameLoop starting frame (00:00:00.017 on in-game timer)
+                            m_snapshot._ticks = m_all_time_stats._ticks;
                             AchievementManager.Field("m_snapshot").SetValue(m_snapshot);
                         }
                         else

--- a/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
+++ b/WorkshopPlus/JumpKingTAS/JKAddons/Manager.cs
@@ -124,8 +124,9 @@ namespace JumpKingTAS
 
                             var m_snapshot = AchievementManager.Field("m_snapshot").GetValue<PlayerStats>();
                             // Same as GameLoop starting frame (00:00:00.017 on in-game timer)
-                            m_snapshot._ticks = m_all_time_stats._ticks;
-                            AchievementManager.Field("m_snapshot").SetValue(m_snapshot);
+                            // reset all time ticks bc FrameState record all time ticks but not snapshot ticks
+                            m_all_time_stats._ticks = m_snapshot._ticks;
+                            AchievementManager.Field("m_all_time_stats").SetValue(m_all_time_stats);
                         }
                         else
                         if (controller.Current.HasActions(Actions.State) && GameLoop.m_player != null)

--- a/WorkshopPlus/JumpKingTAS/Studio/Entities/InputRecord.cs
+++ b/WorkshopPlus/JumpKingTAS/Studio/Entities/InputRecord.cs
@@ -5,14 +5,17 @@ namespace TASStudio.Entities {
 	public enum Actions {
 		None,
 		Left = 1,
-		Right = 2,
-		Up = 4,
-		Down = 8,
-		Jump = 16,
-		Pause = 32,
-		Cancel = 64,
-		Reset = 128,
-		State = 256
+		Right = 1<<1,
+		Up = 1<<2,
+		Down = 1<<3,
+		Jump = 1<<4,
+		Pause = 1<<5,
+		Cancel = 1<<6,
+		Reset = 1<<7,
+		State = 1<<8,
+		Boots = 1<<9,
+		Snake = 1<<10,
+
 	}
 	public class InputRecord {
 		public static char Delimiter = ',';
@@ -68,6 +71,8 @@ namespace TASStudio.Entities {
 					case 'P': Actions ^= Actions.Pause; break;
 					case 'C': Actions ^= Actions.Cancel; break;
 					case 'X': Actions ^= Actions.Reset; break;
+					case 'B': Actions ^= Actions.Boots; break;
+					case 'S': Actions ^= Actions.Snake; break;
 				}
 
 				index++;
@@ -122,6 +127,8 @@ namespace TASStudio.Entities {
 			if (HasActions(Actions.Pause)) { sb.Append(",P"); }
 			if (HasActions(Actions.Cancel)) { sb.Append(",C"); }
 			if (HasActions(Actions.Reset)) { sb.Append(",X"); }
+			if (HasActions(Actions.Boots)) { sb.Append(",B"); }
+			if (HasActions(Actions.Snake)) { sb.Append(",S"); }
 			if (HasActions(Actions.State)) { sb.Append($"@{PosX},{PosY},{Direction}"); }
 			return sb.ToString();
 		}


### PR DESCRIPTION
Hi, this is my first pull request on GitHub. Below are the changes made to JumpKingTAS in this PR:  

## Bug Fixes  
1. Fixed a crash that occurs when starting playback in `jumpking.tas` without any input defined.  
2. Corrected the handling of the "pressed" state:  
   - Previously, using inputs like `9999,J` (to maintain neutral jumps) or `5,D` (to move down five times in the menu) worked in TAS but were not achievable with real manual input.  
3. (12/27 Update) Resolved an issue where stepbacking could leave the player unable to move when the Giant Boots was on:
   - In certain cases, stepbacking would disable the player's body component without re-enabling it, causing movement to become locked. This fix ensures the body component is properly re-enabled during stepbacking.

## New Features  
1. Added input codes for hotkeys to toggle certain items:  
   - **Giant Boots**: `'B'`  
   - **Snake Ring**: `'S'`  
2. Implemented keyboard controls for TAS playback:  
   - **Right Shift**: Resumes normal TAS playback (equivalent to the left stick on a controller).  
   - **Right Alt + Right Ctrl**: Enables TAS step-back mode at 1x speed (equivalent to the right stick X- on a controller).  

## Changes  
1. Updated `Actions.Reset` to only reset the current game ticks.  
   - Previously, this action reset both all-time and snapshot statistics, mimicking the behavior of starting a new save file. This functionality seemed overly destructive.  
   - If this change is not accepted, I recommend adding a warning about the potential risks to the workshop page or GitHub README.  

## Testing and Results  
I’ve tested this modified version locally and used it to record a TAS run successfully. You can see the result here: [https://www.youtube.com/watch?v=u6jYYengQ0c](https://www.youtube.com/watch?v=u6jYYengQ0c). Other tests have also been conducted to ensure the new features work as intended.  

Thank you for reviewing this PR!
