### PR TITLE
Fix compatibility issue with UpSide down player draw.

### DIFF
--- a/WorkshopPlus/JumpKingHitboxResizer/JumpKingHitboxResizer.csproj
+++ b/WorkshopPlus/JumpKingHitboxResizer/JumpKingHitboxResizer.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ModEntry.cs" />
+    <Compile Include="Patches\PrefixPlayerEntityDraw.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
@@ -1,15 +1,9 @@
 ﻿using HarmonyLib;
+using HitboxResizer.Patches;
 using JumpKing;
 using JumpKing.GameManager;
-using JumpKing.Level;
 using JumpKing.Mods;
-using JumpKing.Player;
-using JumpKing.Workshop;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Diagnostics;
-using System.Text;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace HitboxResizer
@@ -20,11 +14,8 @@ namespace HitboxResizer
         const string IDENTIFIER = "Phoenixx19.HitboxResizer";
         const string HARMONY_IDENTIFIER = "Phoenixx19.HitboxResizer.Harmony";
 
-        const string FLAG_REGEX = "^KingCustomHitbox(Width|Height)=[0-9]+$";
+        const string FLAG_REGEX = "^KingCustomHitbox(Width|Height)=([0-9]+)$";
         internal static Regex HitboxResizerRegEx = new Regex(FLAG_REGEX);
-
-        public static int Width { get; set; } = PlayerValues.PLAYER_WIDTH;
-        public static int Height { get; set; } = PlayerValues.PLAYER_HEIGHT;
 
         /// <summary>
         /// Called by Jump King before the level loads
@@ -33,49 +24,11 @@ namespace HitboxResizer
         public static void BeforeLevelLoad()
         {
             var harmony = new Harmony(HARMONY_IDENTIFIER);
-
 #if DEBUG
             Debugger.Launch();
             Harmony.DEBUG = true;
 #endif
-
-            harmony.Patch(
-                AccessTools.Method(typeof(PlayerEntity), "Draw"),
-                prefix: new HarmonyMethod(AccessTools.Method(typeof(ModEntry), nameof(DrawOverride)))
-            );
-        }
-
-        static bool DrawOverride(PlayerEntity __instance)
-        {
-            var center = __instance.m_body.Position + new Vector2(Width / 2, Height);
-
-            var tInstance = Traverse.Create(__instance);
-            tInstance.Field("m_sprite").GetValue<Sprite>()
-                .Draw(
-                    Camera.TransformVector2(center), 
-                    tInstance.Field("m_flip").GetValue<SpriteEffects>()
-                );
-
-            if (LevelScreen.DrawDebug)
-            {
-                Game1.spriteBatch.Draw(
-                    Game1.instance.contentManager.Pixel.texture,
-                    new Rectangle(
-                        Camera.TransformVector2(new Vector2(__instance.m_body.Position.X, __instance.m_body.Position.Y)).ToPoint(),
-                        new Vector2(Width, Height).ToPoint()
-                    ),
-                    new Color(Color.DarkKhaki, 0.66f)
-                );
-
-                Game1.spriteBatch.Draw(
-                    Game1.instance.contentManager.Pixel.texture,
-                    new Rectangle(
-                        Camera.TransformVector2(__instance.m_body.GetHitbox().Center.ToVector2()).ToPoint(), new Point(1)
-                    ),
-                    Color.Red
-                );
-            }
-            return false;
+            harmony.PatchAll(Assembly.GetExecutingAssembly());
         }
 
         /// <summary>
@@ -85,75 +38,70 @@ namespace HitboxResizer
         public static void OnLevelStart()
         {
             // custom hitboxes time
-            if (HasAnyHitboxResizerTags(out int width, out int height))
+            PrefixPlayerEntityDraw.IsCustomHitbox = HasAnyHitboxResizerTags(
+                out var width,
+                out var height);
+            if (PrefixPlayerEntityDraw.IsCustomHitbox)
             {
                 SetHitbox(width, height);
-                return;
             }
-
-            // read default hitboxes
-            SetHitbox();
         }
 
+        /// <summary>
+        /// Checks the level tags for the occurence of our tag.
+        /// </summary>
+        /// <param name="width">Vanilla width or tag specified width.</param>
+        /// <param name="height">Vanilla height or tag specified heigth.</param>
+        /// <returns>True if at least one resize tag has been found, false otherwise.</returns>
         private static bool HasAnyHitboxResizerTags(out int width, out int height)
         {
             // fallback values
             width = PlayerValues.PLAYER_WIDTH;
             height = PlayerValues.PLAYER_HEIGHT;
-            bool isDefault = true;
 
             // null check
-            if (Game1.instance.contentManager?.level?.Info.Tags is null)
+            var tags = Game1.instance.contentManager?.level?.Info.Tags;
+            if (tags is null)
             {
-                return !isDefault;
+                return false;
             }
 
-            foreach (string item in Game1.instance.contentManager.level.Info.Tags)
+            bool isCustom = false;
+            foreach (string tag in tags)
             {
+                var match = HitboxResizerRegEx.Match(tag);
                 // no match found! (most probably its a different flag)
-                if (!HitboxResizerRegEx.IsMatch(item))
+                if (!match.Success)
                 {
                     continue;
                 }
-
-                // KingCustomHitboxWidth=18
-                // dividing it to:
-                // KingCustomHitboxWidth AND 18
-                string[] strings = item.Split('=');
-
-                // this gotta be divided in 2 and it has to be a NUMBER OF SOME SORT
-                if (strings.Length != 2 || !int.TryParse(strings[1], out int value))
+                isCustom = true;
+                // If the regex matches we have captured three groups.
+                // groups[0]: Full tag.
+                // groups[1]: Either Width or Height.
+                // groups[2]: New size.
+                var groups = match.Groups;
+                var value = int.Parse(groups[2].Value);
+                if (groups[1].Value == "Width")
                 {
-                    // uh oh
-                    continue;
-                }
-
-                if (strings[0].Contains("Width"))
-                {
-                    // set width
                     width = value;
                 }
-                else if (strings[0].Contains("Height"))
+                else
                 {
-                    // set height
                     height = value;
                 }
-
-                // i gotta return something as a bool for a feedback!
-                isDefault = false;
             }
-
-            return !isDefault;
+            return isCustom;
         }
 
         private static void SetHitbox(int width = PlayerValues.PLAYER_WIDTH, int height = PlayerValues.PLAYER_HEIGHT)
         {
-            Width = width;
-            Height = height;
+            PrefixPlayerEntityDraw.Width = width;
+            PrefixPlayerEntityDraw.Height = height;
 
             var tBody = Traverse.Create(GameLoop.m_player.m_body);
-            tBody.Field("m_width").SetValue(Width);
-            tBody.Field("m_height").SetValue(Height);
+            tBody.Field("m_width").SetValue(PrefixPlayerEntityDraw.Width);
+            tBody.Field("m_height").SetValue(PrefixPlayerEntityDraw.Height);
         }
     }
 }

--- a/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/ModEntry.cs
@@ -3,6 +3,7 @@ using HitboxResizer.Patches;
 using JumpKing;
 using JumpKing.GameManager;
 using JumpKing.Mods;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -41,6 +42,7 @@ namespace HitboxResizer
             PrefixPlayerEntityDraw.IsCustomHitbox = HasAnyHitboxResizerTags(
                 out var width,
                 out var height);
+
             if (PrefixPlayerEntityDraw.IsCustomHitbox)
             {
                 SetHitbox(width, height);
@@ -67,21 +69,29 @@ namespace HitboxResizer
             }
 
             bool isCustom = false;
+
             foreach (string tag in tags)
             {
                 var match = HitboxResizerRegEx.Match(tag);
+
                 // no match found! (most probably its a different flag)
                 if (!match.Success)
                 {
                     continue;
                 }
+
                 isCustom = true;
+                
                 // If the regex matches we have captured three groups.
                 // groups[0]: Full tag.
                 // groups[1]: Either Width or Height.
                 // groups[2]: New size.
                 var groups = match.Groups;
+
+                // I thought of changing this to int.TryParse
+                // but we established from the Regex that the value will be a number.
                 var value = int.Parse(groups[2].Value);
+
                 if (groups[1].Value == "Width")
                 {
                     width = value;
@@ -91,6 +101,7 @@ namespace HitboxResizer
                     height = value;
                 }
             }
+
             return isCustom;
         }
 

--- a/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
@@ -10,9 +10,28 @@ namespace HitboxResizer.Patches
     [HarmonyPatch(typeof(PlayerEntity), "Draw")]
     public class PrefixPlayerEntityDraw
     {
+        #region Properties
+        /// <summary>
+        /// <c>true</c> if we use the HitboxResizer, <c>false</c> if we don't.
+        /// </summary>
         public static bool IsCustomHitbox { get; set; } = false;
+
+        /// <summary>
+        /// Player width size.
+        /// </summary>
         public static int Width { get; set; } = PlayerValues.PLAYER_WIDTH;
+
+        /// <summary>
+        /// Player height size.
+        /// </summary>
         public static int Height { get; set; } = PlayerValues.PLAYER_HEIGHT;
+        #endregion
+
+        // TODO: Rewrite this as a Transpiler so we have shared compatibility with JeFi's mod to mention his message:
+        //  "The problem is, in our mods we both patch PlayerEntity.Draw(). In my UpsideDownCore
+        //  (https://github.com/JeFi-314/JumpKing-UpsideDownCore/blob/main/UpsideDownCore/Patching/PlayerEntity.cs),
+        //  i used transpiler to directly change original method body;
+        //  but in hitbox resizer, it used prefix patch to skip method body."
 
         public static bool Prefix(PlayerEntity __instance)
         {

--- a/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
@@ -27,12 +27,6 @@ namespace HitboxResizer.Patches
         public static int Height { get; set; } = PlayerValues.PLAYER_HEIGHT;
         #endregion
 
-        // TODO: Rewrite this as a Transpiler so we have shared compatibility with JeFi's mod to mention his message:
-        //  "The problem is, in our mods we both patch PlayerEntity.Draw(). In my UpsideDownCore
-        //  (https://github.com/JeFi-314/JumpKing-UpsideDownCore/blob/main/UpsideDownCore/Patching/PlayerEntity.cs),
-        //  i used transpiler to directly change original method body;
-        //  but in hitbox resizer, it used prefix patch to skip method body."
-
         public static bool Prefix(PlayerEntity __instance)
         {
             if (!IsCustomHitbox)

--- a/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
+++ b/WorkshopPlus/JumpKingHitboxResizer/Patches/PrefixPlayerEntityDraw.cs
@@ -1,0 +1,58 @@
+﻿using HarmonyLib;
+using JumpKing;
+using JumpKing.Level;
+using JumpKing.Player;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HitboxResizer.Patches
+{
+    [HarmonyPatch(typeof(PlayerEntity), "Draw")]
+    public class PrefixPlayerEntityDraw
+    {
+        public static bool IsCustomHitbox { get; set; } = false;
+        public static int Width { get; set; } = PlayerValues.PLAYER_WIDTH;
+        public static int Height { get; set; } = PlayerValues.PLAYER_HEIGHT;
+
+        public static bool Prefix(PlayerEntity __instance)
+        {
+            if (!IsCustomHitbox)
+            {
+                // If we don't have any custom hitbox allow the original method.
+                // For full compatibility with the mod that flips the player
+                // upside down this will have to be a transpiler.
+                return true;
+            }
+
+            var center = __instance.m_body.Position + new Vector2(Width / 2, Height);
+
+            var tInstance = Traverse.Create(__instance);
+            tInstance.Field("m_sprite").GetValue<Sprite>()
+                .Draw(
+                    Camera.TransformVector2(center),
+                    tInstance.Field("m_flip").GetValue<SpriteEffects>()
+                );
+
+            if (LevelScreen.DrawDebug)
+            {
+                Game1.spriteBatch.Draw(
+                    Game1.instance.contentManager.Pixel.texture,
+                    new Rectangle(
+                        Camera.TransformVector2(new Vector2(__instance.m_body.Position.X, __instance.m_body.Position.Y)).ToPoint(),
+                        new Vector2(Width, Height).ToPoint()
+                    ),
+                    new Color(Color.DarkKhaki, 0.66f)
+                );
+
+                Game1.spriteBatch.Draw(
+                    Game1.instance.contentManager.Pixel.texture,
+                    new Rectangle(
+                        Camera.TransformVector2(__instance.m_body.GetHitbox().Center.ToVector2()).ToPoint(), new Point(1)
+                    ),
+                    Color.Red
+                );
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The issue will happen again if the mods are used together, however it will make it so users do not have to unsubscribe this mod.

All changes:
- Change harmony patching to use the [HarmonyPatch] annotation from manual patching.
- Move patching into its own file inside the Patches folder. Overly precise name.
- Remove unused imports (my editor does it automatically, you can add them back if you want, but they are unused).
- Change the regex to capture the new specified size into a group.
- Move Width and Height into the patch file, if you disagree on their new placement you may move them back.
- We do not have to change the Kings hitbox to default since a new King with correct sizes is created when you load the level, the only persistent game element afaik is blocks.
- Make use of the regex captured groups.
- We can parse the int with confidence, since the regex would have failed in cases that parsing would have failed.

Very important note:
- I hate Visual Studio